### PR TITLE
move postgres version to default directory able to customize

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+postgresql_apt_package: postgresql-9.6
+
 postgresql_search_config_path: "{{ playbook_dir }}/files/groups/{{ item }}/postgresql"
 postgresql_search_config_paths: []
 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,4 @@
 ---
-postgresql_apt_package: postgresql-9.6
-postgresql_apt_key_url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
 postgresql_apt_repo: deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main
+postgresql_apt_key_url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
 postgresql_service_name: postgres


### PR DESCRIPTION
Due to `postgresql_apt_package` should be custom the version so I have to move the variable to default directory instead.