### PR TITLE
Fix psycopg2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-postgresql_version: "11"
+postgresql_version: "12"
 postgresql_apt_package: "postgresql-{{ postgresql_version }}"
 
 postgresql_search_config_path: "{{ playbook_dir }}/files/groups/{{ item }}/postgresql"

--- a/tasks/postgresql_pre.yml
+++ b/tasks/postgresql_pre.yml
@@ -9,6 +9,6 @@
 
 - name: Install required packages for PostgreSQL configuration
   apt:
-    name: python3-psycopg2
+    name: "{{ 'python3-psycopg2' if ansible_python.version.major == 3 else 'python-psycopg2' }}"
     state: present
     update_cache: yes


### PR DESCRIPTION
- Bump to PostgreSQL version 12
- Fix install psycopg2 to depends on Ansible Python version